### PR TITLE
Enable live configuration updates from GUI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -270,9 +270,11 @@ export PUSHTOALK_CONFIG_PATH="/custom/path/config.json"
 
 ### Configuration Integration
 - **JSON Config**: All settings persisted locally
-- **Real-time Updates**: GUI changes trigger component reinitialization
+- **Real-time Updates**: GUI changes trigger component reinitialization and now propagate instantly to running sessions through `_notify_config_changed()`
 - **Platform Defaults**: OS-specific hotkey and path defaults
 - **Validation**: Input validation in GUI with error handling
+- **Live Update Internals**: Tk variables use `trace_add`/`trace` to call `_on_config_var_changed()`, which debounces updates and forwards new configs to `PushToTalkApp.update_configuration()` and optional callbacks. Suspend traces with `_suspend_change_events` during programmatic GUI refreshes to avoid loops.
+- **Testing Expectations**: When adding config fields, update both GUI variable initialization and `tests/test_config_gui.CONFIG_VAR_KEYS` so auto-update tests remain accurate.
 
 ## Performance and Scalability Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 - Added unit tests for utils and push_to_talk to reach 80% coverage.
+- Live configuration callbacks in the GUI so running sessions immediately pick up updated settings and glossary edits.
 
 ### Changed
 - Refactored logging system to use loguru. Set the global logger in `main.py` and `tests/conftest.py` once is enough.
+- Configuration GUI now traces Tk variables, debounces updates, and refreshes the status banner whenever settings change mid-session.
 
 ### Deprecated
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,8 +102,14 @@ The application uses multiple threads to prevent blocking:
 - **Primary**: `push_to_talk_config.json` file with all settings including custom glossary
 - **Fallback**: Environment variable `OPENAI_API_KEY` for API key
 - **Platform-specific defaults**: Different hotkeys for macOS (cmd) vs Windows/Linux (ctrl)
-- **Real-time updates**: Configuration changes trigger component reinitialization
+- **Real-time updates**: Tk variable traces call `_notify_config_changed()` which debounces GUI edits and pushes new `PushToTalkConfig` objects into the running app via `PushToTalkApp.update_configuration()`
 - **Custom Glossary**: Stored as `custom_glossary: ["term1", "term2"]` in config JSON
+
+### Live Configuration Updates
+- `_setup_variable_traces()` attaches `trace_add("write", ...)` listeners to every Tk variable once the GUI is built.
+- `_on_config_var_changed()` debounces edits via `after(300, ...)` to avoid excessive reinitialization and supports headless invocation when no Tk root exists (see `tests/test_config_gui.py`).
+- `_notify_config_changed()` copies glossary lists, short-circuits when values are unchanged unless `force=True`, and relays updates to `on_config_changed` callbacks and active app instances.
+- When adding new config fields, update both `ConfigurationGUI.config_vars` setup and `tests/test_config_gui.CONFIG_VAR_KEYS` so tests keep covering auto-update behaviour.
 
 ### Testing Structure
 

--- a/README.md
+++ b/README.md
@@ -85,10 +85,25 @@ The application features a comprehensive, persistent configuration GUI with orga
 - **Live Updates Banner**: Status automatically refreshes when settings change mid-session
 
 ### Live Configuration Updates
+
+The application features a sophisticated real-time configuration system that applies changes instantly while running:
+
+#### How It Works
+- **Variable Tracing**: Every GUI field (text boxes, checkboxes, dropdowns) automatically detects changes using Tkinter variable traces
+- **Smart Debouncing**: Rapid typing is intelligently handled with a 300ms delay to prevent excessive updates
+- **Selective Reinitialization**: Only components affected by changes are reinitialized (e.g., hotkey changes → restart hotkey service)
+- **Service Continuity**: Critical services like hotkey detection automatically restart after updates
+
+#### Technical Features
 - **Instant Propagation**: Editing any field triggers a debounced update to the running PushToTalk service
 - **Callback Support**: Optional listeners receive configuration dataclasses whenever values change
 - **Glossary Sync**: Glossary edits are copied before rebuilds to prevent UI/model divergence
 - **Safe Programmatic Updates**: GUI refreshes suspend traces to avoid infinite callback loops
+
+#### Example Scenarios
+- **Hotkey Change**: Type "ctrl+alt+space" → Only final result triggers one hotkey service restart
+- **Non-Critical Change**: Toggle "Audio Feedback" → Updates instantly without restarting core components
+- **API Key Change**: Update OpenAI key → Only transcription/refinement components reinitialize
 
 ### API Settings
 - **OpenAI API Key**: Secure entry with show/hide functionality

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A Python application that provides push-to-talk speech-to-text functionality wit
 ## Features
 
 - **🎯 GUI Interface**: Integrated configuration control and application status monitoring in one window
+- **🔄 Live Config Sync**: GUI edits instantly push updates to the running background service—no restart required
 - **📚 Custom Glossary**: Add domain-specific terms and acronyms to improve transcription accuracy
 - **✨ Text Refinement**: Improves transcription quality using Refinement Models
 - **🤖 Speech-to-Text**: Uses OpenAI transcription service for accurate transcription
@@ -46,10 +47,12 @@ See [issues](https://github.com/yixin0829/push-to-talk/issues) for more details.
    - **Monitor status** with real-time indicators (green = running, gray = stopped)
    - **View active settings** displayed when running
    - **Easy control** with "Stop Application" button to terminate
+   - **Tweak settings live**—changes made while running apply instantly
 
 3. **Daily usage**:
    - GUI provides persistent control and status monitoring
    - Use your configured hotkeys to record and transcribe
+   - Tune preferences without stopping the service; hotkeys update in real time
    - Start/stop the service anytime from the GUI
 
 ### For Developers
@@ -79,6 +82,13 @@ The application features a comprehensive, persistent configuration GUI with orga
   - **Gray circle + "Ready to start"**: Application stopped
   - **Green circle + "Running - Use your configured hotkeys"**: Application running
 - **Active Settings Display**: Shows current hotkeys and enabled features when running
+- **Live Updates Banner**: Status automatically refreshes when settings change mid-session
+
+### Live Configuration Updates
+- **Instant Propagation**: Editing any field triggers a debounced update to the running PushToTalk service
+- **Callback Support**: Optional listeners receive configuration dataclasses whenever values change
+- **Glossary Sync**: Glossary edits are copied before rebuilds to prevent UI/model divergence
+- **Safe Programmatic Updates**: GUI refreshes suspend traces to avoid infinite callback loops
 
 ### API Settings
 - **OpenAI API Key**: Secure entry with show/hide functionality
@@ -136,6 +146,7 @@ The application supports both GUI and file-based configuration:
 - Launch the application to access the integrated configuration interface
 - **All settings** validated and saved automatically to `push_to_talk_config.json`
 - **Real-time status** shows application state with visual indicators
+- **Auto-sync**: Edits instantly update the running background service and any registered callbacks
 - Every time you start the application, your configuration is saved and overwrites the old configuration in the JSON file `push_to_talk_config.json`
 
 ### File-Based Configuration

--- a/src/config_gui.py
+++ b/src/config_gui.py
@@ -41,6 +41,14 @@ class ConfigurationGUI:
         self.status_indicator = None
         self.settings_frame = None
 
+        # Configuration change tracking
+        self._variable_traces: list[tuple[tk.Variable, str]] = []
+        self._suspend_change_events = False
+        self._pending_update_job: Optional[str] = None
+
+        # Glossary state (available even before the GUI is created)
+        self.glossary_terms = list(self.config.custom_glossary)
+
     def create_gui(self) -> tk.Tk:
         """Create and return the main GUI window."""
         self.root = tk.Tk()
@@ -92,6 +100,9 @@ class ConfigurationGUI:
         self._create_feature_flags_section(scrollable_frame)
         self._create_status_section(scrollable_frame)
         self._create_buttons_section(scrollable_frame)
+
+        # Monitor configuration variables for live updates
+        self._setup_variable_traces()
 
         # Center the window
         self.root.update_idletasks()
@@ -223,6 +234,68 @@ Configure your settings below, then click "Start Application" to begin:"""
         """Hide the active settings display."""
         if self.settings_frame:
             self.settings_frame.pack_forget()
+
+    def _setup_variable_traces(self):
+        """Attach trace callbacks to configuration variables for live updates."""
+        if self._variable_traces:
+            return
+
+        self._suspend_change_events = True
+        try:
+            for var in self.config_vars.values():
+                try:
+                    trace_id = var.trace_add("write", self._on_config_var_changed)
+                except AttributeError:
+                    trace_id = var.trace("w", self._on_config_var_changed)
+                self._variable_traces.append((var, trace_id))
+        finally:
+            self._suspend_change_events = False
+
+    def _on_config_var_changed(self, *args):
+        """Handle configuration variable changes from the GUI."""
+        if self._suspend_change_events:
+            return
+
+        if self.root and self.root.winfo_exists():
+            if self._pending_update_job:
+                try:
+                    self.root.after_cancel(self._pending_update_job)
+                except Exception:
+                    pass
+            self._pending_update_job = self.root.after(300, self._apply_config_changes)
+        else:
+            self._apply_config_changes()
+
+    def _apply_config_changes(self, force: bool = False):
+        """Apply GUI-driven configuration changes."""
+        self._pending_update_job = None
+        self._notify_config_changed(force=force)
+
+    def _notify_config_changed(self, *, force: bool = False):
+        """Notify listeners and running app about configuration changes."""
+        new_config = self._get_config_from_gui()
+
+        if not force and new_config == self.config:
+            return
+
+        self.config = new_config
+
+        if self.on_config_changed:
+            try:
+                self.on_config_changed(new_config)
+            except Exception as error:
+                logger.error(f"Error in configuration change callback: {error}")
+
+        if self.is_running and self.app_instance:
+            try:
+                self.app_instance.update_configuration(new_config)
+            except Exception as error:
+                logger.error(
+                    f"Failed to update running application configuration: {error}"
+                )
+
+        if self.is_running:
+            self._update_status_display()
 
     def _create_section_frame(self, parent: ttk.Widget, title: str) -> ttk.LabelFrame:
         """Create a labeled frame for a configuration section."""
@@ -634,6 +707,9 @@ Configure your settings below, then click "Start Application" to begin:"""
 
     def _refresh_glossary_list(self):
         """Refresh the glossary list display."""
+        if not hasattr(self, "glossary_listbox") or self.glossary_listbox is None:
+            return
+
         self.glossary_listbox.delete(0, tk.END)
         for term in sorted(self.glossary_terms, key=str.lower):
             self.glossary_listbox.insert(tk.END, term)
@@ -648,6 +724,7 @@ Configure your settings below, then click "Start Application" to begin:"""
             if term not in self.glossary_terms:
                 self.glossary_terms.append(term)
                 self._refresh_glossary_list()
+                self._notify_config_changed()
             else:
                 messagebox.showinfo(
                     "Duplicate Term", f"The term '{term}' is already in the glossary."
@@ -674,6 +751,7 @@ Configure your settings below, then click "Start Application" to begin:"""
                     actual_index = self.glossary_terms.index(current_term)
                     self.glossary_terms[actual_index] = new_term
                     self._refresh_glossary_list()
+                    self._notify_config_changed()
                 else:
                     messagebox.showinfo(
                         "Duplicate Term",
@@ -695,6 +773,7 @@ Configure your settings below, then click "Start Application" to begin:"""
         ):
             self.glossary_terms.remove(term)
             self._refresh_glossary_list()
+            self._notify_config_changed()
 
     def _create_buttons_section(self, parent: ttk.Widget):
         """Create buttons section."""
@@ -784,24 +863,37 @@ Configure your settings below, then click "Start Application" to begin:"""
 
     def _update_gui_from_config(self, config: PushToTalkConfig):
         """Update GUI fields from a configuration object."""
-        self.config_vars["openai_api_key"].set(config.openai_api_key)
-        self.config_vars["stt_model"].set(config.stt_model)
-        self.config_vars["refinement_model"].set(config.refinement_model)
-        self.config_vars["sample_rate"].set(config.sample_rate)
-        self.config_vars["chunk_size"].set(config.chunk_size)
-        self.config_vars["channels"].set(config.channels)
-        self.config_vars["hotkey"].set(config.hotkey)
-        self.config_vars["toggle_hotkey"].set(config.toggle_hotkey)
-        self.config_vars["insertion_method"].set(config.insertion_method)
-        self.config_vars["insertion_delay"].set(config.insertion_delay)
-        self.config_vars["enable_text_refinement"].set(config.enable_text_refinement)
-        self.config_vars["enable_logging"].set(config.enable_logging)
-        self.config_vars["enable_audio_feedback"].set(config.enable_audio_feedback)
-        self.config_vars["enable_audio_processing"].set(config.enable_audio_processing)
-        self.config_vars["debug_mode"].set(config.debug_mode)
-        self.config_vars["silence_threshold"].set(config.silence_threshold)
-        self.config_vars["min_silence_duration"].set(config.min_silence_duration)
-        self.config_vars["speed_factor"].set(config.speed_factor)
+        self._suspend_change_events = True
+        try:
+            self.config_vars["openai_api_key"].set(config.openai_api_key)
+            self.config_vars["stt_model"].set(config.stt_model)
+            self.config_vars["refinement_model"].set(config.refinement_model)
+            self.config_vars["sample_rate"].set(config.sample_rate)
+            self.config_vars["chunk_size"].set(config.chunk_size)
+            self.config_vars["channels"].set(config.channels)
+            self.config_vars["hotkey"].set(config.hotkey)
+            self.config_vars["toggle_hotkey"].set(config.toggle_hotkey)
+            self.config_vars["insertion_method"].set(config.insertion_method)
+            self.config_vars["insertion_delay"].set(config.insertion_delay)
+            self.config_vars["enable_text_refinement"].set(
+                config.enable_text_refinement
+            )
+            self.config_vars["enable_logging"].set(config.enable_logging)
+            self.config_vars["enable_audio_feedback"].set(config.enable_audio_feedback)
+            self.config_vars["enable_audio_processing"].set(
+                config.enable_audio_processing
+            )
+            self.config_vars["debug_mode"].set(config.debug_mode)
+            self.config_vars["silence_threshold"].set(config.silence_threshold)
+            self.config_vars["min_silence_duration"].set(config.min_silence_duration)
+            self.config_vars["speed_factor"].set(config.speed_factor)
+        finally:
+            self._suspend_change_events = False
+
+        self.glossary_terms = list(config.custom_glossary)
+        self._refresh_glossary_list()
+
+        self._notify_config_changed(force=True)
 
     def _get_config_from_gui(self) -> PushToTalkConfig:
         """Create a configuration object from current GUI values."""
@@ -824,7 +916,7 @@ Configure your settings below, then click "Start Application" to begin:"""
             silence_threshold=self.config_vars["silence_threshold"].get(),
             min_silence_duration=self.config_vars["min_silence_duration"].get(),
             speed_factor=self.config_vars["speed_factor"].get(),
-            custom_glossary=self.glossary_terms,
+            custom_glossary=list(self.glossary_terms),
         )
 
     def _toggle_application(self):

--- a/tests/test_config_gui.py
+++ b/tests/test_config_gui.py
@@ -1,0 +1,136 @@
+import sys
+import types
+from unittest.mock import Mock
+
+pyautogui_stub = types.SimpleNamespace(
+    hotkey=lambda *_, **__: None,
+    write=lambda *_, **__: None,
+    getActiveWindow=lambda: None,
+)
+
+sys.modules.setdefault("mouseinfo", types.SimpleNamespace())
+sys.modules.setdefault("pyautogui", pyautogui_stub)
+
+
+class _DummyListener:
+    def __init__(self, *_, **__):
+        pass
+
+    def start(self):
+        return None
+
+    def stop(self):
+        return None
+
+    def join(self, *_):
+        return None
+
+
+keyboard_stub = types.SimpleNamespace(
+    Listener=_DummyListener,
+    Key=types.SimpleNamespace,
+    KeyCode=types.SimpleNamespace,
+)
+
+sys.modules.setdefault("pynput", types.SimpleNamespace(keyboard=keyboard_stub))
+sys.modules.setdefault("pynput.keyboard", keyboard_stub)
+
+from src.config_gui import ConfigurationGUI  # noqa: E402
+from src.push_to_talk import PushToTalkConfig  # noqa: E402
+
+
+class DummyVar:
+    def __init__(self, value):
+        self._value = value
+
+    def get(self):
+        return self._value
+
+    def set(self, value):
+        self._value = value
+
+
+CONFIG_VAR_KEYS = [
+    "openai_api_key",
+    "stt_model",
+    "refinement_model",
+    "sample_rate",
+    "chunk_size",
+    "channels",
+    "hotkey",
+    "toggle_hotkey",
+    "insertion_method",
+    "insertion_delay",
+    "enable_text_refinement",
+    "enable_logging",
+    "enable_audio_feedback",
+    "enable_audio_processing",
+    "debug_mode",
+    "silence_threshold",
+    "min_silence_duration",
+    "speed_factor",
+]
+
+
+def _prepare_gui(config: PushToTalkConfig) -> ConfigurationGUI:
+    gui = ConfigurationGUI(config)
+    gui.config_vars = {key: DummyVar(getattr(config, key)) for key in CONFIG_VAR_KEYS}
+    gui.glossary_terms = list(config.custom_glossary)
+    return gui
+
+
+def test_gui_updates_running_app_when_config_changes():
+    config = PushToTalkConfig(openai_api_key="test-key")
+    gui = _prepare_gui(config)
+
+    gui.app_instance = Mock()
+    gui.on_config_changed = Mock()
+    gui.is_running = True
+
+    gui.config_vars["hotkey"].set("ctrl+alt+h")
+    gui._on_config_var_changed()
+
+    gui.app_instance.update_configuration.assert_called_once()
+    updated_config = gui.app_instance.update_configuration.call_args[0][0]
+    assert updated_config.hotkey == "ctrl+alt+h"
+    assert gui.config.hotkey == "ctrl+alt+h"
+    gui.on_config_changed.assert_called_once_with(updated_config)
+
+    # Trigger callback again without changing values and ensure nothing happens
+    gui.app_instance.update_configuration.reset_mock()
+    gui.on_config_changed.reset_mock()
+    gui._on_config_var_changed()
+    gui.app_instance.update_configuration.assert_not_called()
+    gui.on_config_changed.assert_not_called()
+
+
+def test_force_notify_triggers_update_even_when_values_match():
+    config = PushToTalkConfig(openai_api_key="test-key")
+    gui = _prepare_gui(config)
+
+    gui.app_instance = Mock()
+    gui.on_config_changed = Mock()
+    gui.is_running = True
+
+    gui._notify_config_changed(force=True)
+
+    gui.app_instance.update_configuration.assert_called_once()
+    forced_config = gui.app_instance.update_configuration.call_args[0][0]
+    gui.on_config_changed.assert_called_once_with(forced_config)
+    assert forced_config == config
+
+
+def test_custom_glossary_is_copied_when_building_config():
+    config = PushToTalkConfig(openai_api_key="test-key", custom_glossary=["alpha"])
+    gui = _prepare_gui(config)
+
+    gui._notify_config_changed(force=True)
+    assert gui.config.custom_glossary == ["alpha"]
+
+    # Modify GUI glossary without notifying and ensure stored config is unchanged
+    gui.glossary_terms.append("beta")
+    assert gui.config.custom_glossary == ["alpha"]
+
+    # Notify again and confirm the change is propagated
+    gui._notify_config_changed()
+    assert gui.config.custom_glossary == ["alpha", "beta"]

--- a/tests/test_hotkey_service.py
+++ b/tests/test_hotkey_service.py
@@ -62,7 +62,7 @@ keyboard_stub = types.SimpleNamespace(
 sys.modules.setdefault("pynput", types.SimpleNamespace(keyboard=keyboard_stub))
 sys.modules["pynput.keyboard"] = keyboard_stub
 
-from src.hotkey_service import HotkeyService
+from src.hotkey_service import HotkeyService  # noqa: E402
 
 pynput_keyboard = keyboard_stub
 
@@ -173,7 +173,6 @@ class TestHotkeyService:
         assert self.service.is_running is False
         assert self.service.is_recording is False
 
-
     def test_push_to_talk_flow(self):
         """Pressing and releasing the push-to-talk hotkey should start/stop recording."""
 
@@ -262,10 +261,7 @@ class TestHotkeyService:
 
         service = HotkeyService(hotkey="ctrl+shift+space", toggle_hotkey="ctrl+shift+^")
         assert "caret" in service.toggle_hotkey_keys
-        assert (
-            service._key_to_name(pynput_keyboard.KeyCode(char="^"))
-            == "caret"
-        )
+        assert service._key_to_name(pynput_keyboard.KeyCode(char="^")) == "caret"
 
     def test_is_service_running_property(self):
         """Helper accessor should reflect running state."""

--- a/tests/test_push_to_talk.py
+++ b/tests/test_push_to_talk.py
@@ -133,6 +133,7 @@ def dependency_stubs(monkeypatch):
             self.stop_calls = 0
             self.should_start = True
             self.recording_state = "idle"
+            self.is_running = False
             tracker["hotkey_service"].append(self)
 
         def set_callbacks(self, on_start_recording, on_stop_recording):
@@ -140,13 +141,18 @@ def dependency_stubs(monkeypatch):
 
         def start_service(self):
             self.start_calls += 1
+            self.is_running = self.should_start
             return self.should_start
 
         def stop_service(self):
             self.stop_service_calls += 1
+            self.is_running = False
 
         def stop(self):
             self.stop_calls += 1
+
+        def is_service_running(self):
+            return self.is_running
 
     monkeypatch.setattr(push_to_talk, "AudioRecorder", StubAudioRecorder)
     monkeypatch.setattr(push_to_talk, "AudioProcessor", StubAudioProcessor)
@@ -406,7 +412,7 @@ def test_update_configuration_reinitializes(make_app, dependency_stubs):
     app.update_configuration(new_config)
 
     assert dependency_stubs.last("audio_recorder") is not initial_recorder
-    assert initial_service.stop_calls == 1
+    assert initial_service.stop_service_calls == 1
     assert app.config == new_config
 
 
@@ -422,6 +428,33 @@ def test_update_configuration_skips_reinit_when_unchanged(make_app, dependency_s
 
     assert dependency_stubs.last("audio_recorder") is initial_recorder
     assert initial_service.stop_calls == 0
+
+
+def test_update_configuration_restarts_hotkey_service_when_running(
+    make_app, dependency_stubs
+):
+    """Test that hotkey service is restarted during configuration updates when app is running."""
+    app = make_app()
+
+    # Start the application (which should start the hotkey service)
+    app.start(setup_signals=False)
+
+    initial_service = dependency_stubs.last("hotkey_service")
+    assert initial_service.start_calls == 1
+    assert initial_service.is_service_running()
+
+    # Update configuration with a change that requires component reinitialization
+    new_config = replace(app.config, chunk_size=app.config.chunk_size + 1)
+    app.update_configuration(new_config)
+
+    # Should have a new service instance that's been started automatically
+    new_service = dependency_stubs.last("hotkey_service")
+    assert new_service is not initial_service
+    assert initial_service.stop_service_calls == 1
+    assert new_service.start_calls == 1  # New service should be started
+    assert new_service.is_service_running()
+
+    app.stop()
 
 
 def test_toggle_text_refinement_recreates_refiner(make_app, dependency_stubs):
@@ -503,3 +536,116 @@ def test_change_toggle_hotkey_replaces_service(make_app, dependency_stubs):
     assert original_service.stop_calls == 1
     assert new_service.toggle_hotkey == "ctrl+alt+y"
     assert new_service.callbacks == (app._on_start_recording, app._on_stop_recording)
+
+
+def test_config_requires_component_reinitialization():
+    """Test that the requires_component_reinitialization method correctly identifies changes."""
+    base_config = push_to_talk.PushToTalkConfig(
+        openai_api_key="test-key",
+        stt_model="whisper-1",
+        refinement_model="gpt-4o-mini",
+        sample_rate=16000,
+        chunk_size=1024,
+        channels=1,
+        hotkey="ctrl+shift+space",
+        toggle_hotkey="ctrl+shift+^",
+        insertion_delay=0.005,
+        enable_text_refinement=True,
+        enable_audio_processing=True,
+        debug_mode=False,
+        silence_threshold=-16.0,
+        min_silence_duration=400.0,
+        speed_factor=1.5,
+        custom_glossary=["term1", "term2"],
+    )
+
+    # Test that identical configs don't require reinitialization
+    identical_config = replace(base_config)
+    assert not base_config.requires_component_reinitialization(identical_config)
+    assert not identical_config.requires_component_reinitialization(base_config)
+
+    # Test each field that should trigger reinitialization
+    test_cases = [
+        ("openai_api_key", "different-key"),
+        ("stt_model", "whisper-2"),
+        ("refinement_model", "gpt-4"),
+        ("sample_rate", 44100),
+        ("chunk_size", 2048),
+        ("channels", 2),
+        ("hotkey", "ctrl+alt+space"),
+        ("toggle_hotkey", "ctrl+alt+^"),
+        ("insertion_delay", 0.01),
+        ("enable_text_refinement", False),
+        ("enable_audio_processing", False),
+        ("debug_mode", True),
+        ("silence_threshold", -20.0),
+        ("min_silence_duration", 500.0),
+        ("speed_factor", 2.0),
+        ("custom_glossary", ["different", "terms"]),
+    ]
+
+    for field_name, new_value in test_cases:
+        changed_config = replace(base_config, **{field_name: new_value})
+        assert base_config.requires_component_reinitialization(changed_config), (
+            f"Change to {field_name} should require reinitialization"
+        )
+        assert changed_config.requires_component_reinitialization(base_config), (
+            f"Change from {field_name} should require reinitialization"
+        )
+
+
+def test_config_requires_reinitialization_ignores_non_critical_fields():
+    """Test that changes to non-critical fields don't trigger reinitialization."""
+    base_config = push_to_talk.PushToTalkConfig(
+        openai_api_key="test-key",
+        insertion_method="clipboard",
+        enable_logging=True,
+        enable_audio_feedback=True,
+    )
+
+    # Test fields that should NOT trigger reinitialization
+    non_critical_changes = [
+        ("insertion_method", "sendkeys"),
+        ("enable_logging", False),
+        ("enable_audio_feedback", False),
+    ]
+
+    for field_name, new_value in non_critical_changes:
+        changed_config = replace(base_config, **{field_name: new_value})
+        assert not base_config.requires_component_reinitialization(changed_config), (
+            f"Change to {field_name} should NOT require reinitialization"
+        )
+        assert not changed_config.requires_component_reinitialization(base_config), (
+            f"Change from {field_name} should NOT require reinitialization"
+        )
+
+
+def test_update_configuration_uses_requires_reinitialization(
+    make_app, dependency_stubs
+):
+    """Test that update_configuration properly uses the requires_component_reinitialization method."""
+    app = make_app()
+
+    initial_recorder = dependency_stubs.last("audio_recorder")
+    initial_service = dependency_stubs.last("hotkey_service")
+
+    # Change a field that requires reinitialization
+    new_config = replace(app.config, chunk_size=app.config.chunk_size + 1)
+    app.update_configuration(new_config)
+
+    # Should have created new components
+    assert dependency_stubs.last("audio_recorder") is not initial_recorder
+    assert initial_service.stop_service_calls == 1
+    assert app.config == new_config
+
+    # Now test with a change that doesn't require reinitialization
+    current_recorder = dependency_stubs.last("audio_recorder")
+    current_service = dependency_stubs.last("hotkey_service")
+
+    non_critical_config = replace(app.config, insertion_method="sendkeys")
+    app.update_configuration(non_critical_config)
+
+    # Should NOT have created new components
+    assert dependency_stubs.last("audio_recorder") is current_recorder
+    assert current_service.stop_service_calls == 0  # No additional stops
+    assert app.config == non_critical_config

--- a/tests/test_push_to_talk.py
+++ b/tests/test_push_to_talk.py
@@ -14,7 +14,7 @@ pyautogui_stub = types.SimpleNamespace(
 sys.modules.setdefault("mouseinfo", types.SimpleNamespace())
 sys.modules.setdefault("pyautogui", pyautogui_stub)
 
-from src import push_to_talk
+from src import push_to_talk  # noqa: E402
 
 
 class InstanceTracker(defaultdict):
@@ -329,7 +329,9 @@ def test_process_recorded_audio_pipeline(
     assert not processed_path.exists()
 
 
-def test_process_recorded_audio_without_text(make_app, dependency_stubs, feedback_spy, immediate_thread, tmp_path):
+def test_process_recorded_audio_without_text(
+    make_app, dependency_stubs, feedback_spy, immediate_thread, tmp_path
+):
     app = make_app()
     app.config.enable_audio_feedback = False
 


### PR DESCRIPTION
## Summary
- add Tk variable tracing and debounced callbacks so GUI edits update the running app configuration and status display automatically
- ensure programmatic GUI updates suspend traces, refresh glossary safely, and copy glossary entries into new configs
- add headless tests covering configuration change callbacks and update existing tests to satisfy linting
- document the live configuration sync flow in README, CLAUDE.md, AGENTS.md, and CHANGELOG.md

## Testing
- uv run ruff format .
- uv run ruff check . --fix
- uv run pytest tests -v

------
https://chatgpt.com/codex/tasks/task_e_68cdd8a6c6548322ba3e4b7bd423e010